### PR TITLE
7 usage from inside project subdirectories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "assert_fs",
  "clap",
  "predicates",
+ "toml_edit",
 ]
 
 [[package]]
@@ -219,6 +220,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -281,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +313,16 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -510,6 +533,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,3 +667,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.94"
 clap = { version = "4.5.23", features = ["derive"] }
+toml_edit = "0.22.22"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/src/build.rs
+++ b/src/build.rs
@@ -29,6 +29,8 @@ pub fn build_project(current_dir: &Path) -> anyhow::Result<()> {
     };
 
     let project_target = project_root.join("target");
+    ensure_target_dir_exists(&project_target)
+        .with_context(|| "Failed to ensure target directory exists for storing built binaries!")?;
 
     build_src_files(src_files, &project_target, project_name)
         .with_context(|| "Failed to build source files!")?;
@@ -85,6 +87,19 @@ fn find_src_files(project_src: &Path) -> anyhow::Result<HashSet<PathBuf>> {
     );
 
     Ok(src_files)
+}
+
+fn ensure_target_dir_exists(project_target: &Path) -> anyhow::Result<()> {
+    if !project_target.try_exists()? {
+        fs::create_dir(project_target).with_context(|| {
+            format!(
+                "Failed to create project target directory at {}!",
+                project_target.display()
+            )
+        })?;
+    }
+
+    Ok(())
 }
 
 fn build_src_files(

--- a/src/build.rs
+++ b/src/build.rs
@@ -89,7 +89,13 @@ fn find_src_files(project_src: &Path) -> anyhow::Result<HashSet<PathBuf>> {
 }
 
 fn get_project_name(project_manifest: &Path) -> anyhow::Result<String> {
-    let manifest = toml_edit::DocumentMut::from_str(&fs::read_to_string(project_manifest)?)?;
+    let manifest = toml_edit::DocumentMut::from_str(&fs::read_to_string(project_manifest)?)
+        .with_context(|| {
+            format!(
+                "Failed to parse project manifest {}!",
+                project_manifest.display()
+            )
+        })?;
     let Some(project_name) = manifest["project"]["name"].as_str() else {
         anyhow::bail!("Failed to gather project name!")
     };

--- a/src/build.rs
+++ b/src/build.rs
@@ -42,7 +42,10 @@ fn find_project_root(dir: &Path) -> anyhow::Result<PathBuf> {
             if let Some(parent) = manifest.path().parent() {
                 parent.to_path_buf()
             } else {
-                anyhow::bail!("Couldn't get root!");
+                anyhow::bail!(format!(
+                    "Found manifest {} has no parent directory to use as project root!",
+                    manifest.path().display()
+                ));
             }
         }
         None => {
@@ -50,7 +53,7 @@ fn find_project_root(dir: &Path) -> anyhow::Result<PathBuf> {
                 find_project_root(parent_dir)?
             } else {
                 anyhow::bail!(format!(
-                    "Failed to find project root up to {}!",
+                    "Failed to find `Cppargo.toml` up to {}!",
                     dir.display()
                 ))
             }

--- a/src/build.rs
+++ b/src/build.rs
@@ -216,7 +216,8 @@ mod tests {
                     anyhow::bail!(format!("Found some project root at {}!", root.display()))
                 }
                 Err(err) => {
-                    if err.to_string() != "Failed to find `Cppargo.toml` up to /!" {
+                    if err.to_string() != "Failed to find project manifest `Cppargo.toml` up to /!"
+                    {
                         anyhow::bail!(format!(
                             "Got a non-expected error: \"{}\"!",
                             err.to_string()

--- a/src/build.rs
+++ b/src/build.rs
@@ -479,21 +479,23 @@ mod tests {
     }
 
     #[test]
-    fn proper_build_project() -> anyhow::Result<()> {
+    fn proper_main() -> anyhow::Result<()> {
         let project_root = assert_fs::TempDir::new()?;
         let project_src = project_root.child("src");
         let project_target = project_root.child("target");
         project_target.create_dir_all()?;
+
+        let project_manifest = project_root.child("Cppargo.toml");
+        project_manifest.write_str(PROJECT_MANIFEST)?;
 
         let main_file = project_src.child("main.cpp");
         main_file.write_str(MAIN_FILE_WITH_INCLUDE_MODULE)?;
         let module_file = project_src.child("module.hpp");
         module_file.write_str(MODULE_FILE)?;
 
-        build_project(&project_root)?;
-        let project_name = project_root.file_name().unwrap();
+        main(&project_root)?;
         project_target
-            .child(project_name)
+            .child("foo")
             .assert(predicates::path::is_file());
 
         Ok(())

--- a/src/build.rs
+++ b/src/build.rs
@@ -8,7 +8,7 @@ use std::{
     str::FromStr,
 };
 
-pub fn build_project(current_dir: &Path) -> anyhow::Result<()> {
+pub fn main(current_dir: &Path) -> anyhow::Result<()> {
     let project_root =
         find_project_root(current_dir).with_context(|| "Not at cppargo project root!")?;
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -22,11 +22,7 @@ pub fn build_project(current_dir: &Path) -> anyhow::Result<()> {
     })?;
 
     let project_manifest = project_root.join("Cppargo.toml");
-
-    let manifest = toml_edit::DocumentMut::from_str(&fs::read_to_string(project_manifest)?)?;
-    let Some(project_name) = manifest["project"]["name"].as_str() else {
-        anyhow::bail!("Failed to gather project name!")
-    };
+    let project_name = get_project_name(&project_manifest)?;
 
     let project_target = project_root.join("target");
     ensure_target_dir_exists(&project_target)
@@ -87,6 +83,15 @@ fn find_src_files(project_src: &Path) -> anyhow::Result<HashSet<PathBuf>> {
     );
 
     Ok(src_files)
+}
+
+fn get_project_name(project_manifest: &Path) -> anyhow::Result<String> {
+    let manifest = toml_edit::DocumentMut::from_str(&fs::read_to_string(project_manifest)?)?;
+    let Some(project_name) = manifest["project"]["name"].as_str() else {
+        anyhow::bail!("Failed to gather project name!")
+    };
+
+    Ok(String::from_str(project_name)?)
 }
 
 fn ensure_target_dir_exists(project_target: &Path) -> anyhow::Result<()> {

--- a/src/build.rs
+++ b/src/build.rs
@@ -455,7 +455,8 @@ mod tests {
 
     #[test]
     fn proper_build_src_files() -> anyhow::Result<()> {
-        let project_root = assert_fs::TempDir::new()?;
+        let tmp_dir = assert_fs::TempDir::new()?;
+        let project_root = tmp_dir.child("foo");
         let project_src = project_root.child("src");
         let project_target = project_root.child("target");
         project_target.create_dir_all()?;
@@ -465,9 +466,11 @@ mod tests {
         let module_file = project_src.child("module.hpp");
         module_file.write_str(MODULE_FILE)?;
 
+        let project_binary = project_target.child("foo");
+
         let src_files = HashSet::from([main_file.to_path_buf()]);
-        let project_name = project_root.file_name().unwrap();
-        build_src_files(src_files, project_target.path(), project_name)?;
+        let project_name = "foo";
+        build_src_files(src_files, project_binary.path())?;
         project_target
             .child(project_name)
             .assert(predicates::path::is_file());

--- a/src/build.rs
+++ b/src/build.rs
@@ -9,8 +9,12 @@ use std::{
 };
 
 pub fn main(current_dir: &Path) -> anyhow::Result<()> {
-    let project_root =
-        find_project_root(current_dir).with_context(|| "Not at cppargo project root!")?;
+    let project_root = find_project_root(current_dir).with_context(|| {
+        format!(
+            "Current directory {} is not inside a `cppargo` project!",
+            current_dir.display()
+        )
+    })?;
 
     let project_src = project_root.join("src");
 
@@ -53,7 +57,7 @@ fn find_project_root(dir: &Path) -> anyhow::Result<PathBuf> {
                 find_project_root(parent_dir)?
             } else {
                 anyhow::bail!(format!(
-                    "Failed to find `Cppargo.toml` up to {}!",
+                    "Failed to find project manifest `Cppargo.toml` up to {}!",
                     dir.display()
                 ))
             }

--- a/src/build.rs
+++ b/src/build.rs
@@ -28,8 +28,8 @@ pub fn build_project(current_dir: &Path) -> anyhow::Result<()> {
     ensure_target_dir_exists(&project_target)
         .with_context(|| "Failed to ensure target directory exists for storing built binaries!")?;
 
-    build_src_files(src_files, &project_target, project_name)
-        .with_context(|| "Failed to build source files!")?;
+    let binary_path = project_target.join(project_name);
+    build_src_files(src_files, &binary_path).with_context(|| "Failed to build source files!")?;
     Ok(())
 }
 
@@ -107,18 +107,16 @@ fn ensure_target_dir_exists(project_target: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn build_src_files(
-    src_files: HashSet<PathBuf>,
-    project_target: &Path,
-    project_name: &str,
-) -> anyhow::Result<()> {
-    let output_file = project_target.join(project_name);
-
+fn build_src_files(src_files: HashSet<PathBuf>, binary_path: &Path) -> anyhow::Result<()> {
     let output_args = [
         "-o",
-        output_file
-            .to_str()
-            .expect("Should be able to convert output_file to string"),
+        match binary_path.to_str() {
+            Some(s) => s,
+            None => anyhow::bail!(format!(
+                "Failed to parse binary path to string: {}",
+                binary_path.display()
+            )),
+        },
     ];
 
     let mut compiler = Command::new("g++");

--- a/src/build.rs
+++ b/src/build.rs
@@ -423,6 +423,36 @@ mod tests {
         }
     }
 
+    #[cfg(test)]
+    mod ensure_target_dir_exists {
+        use super::*;
+
+        #[test]
+        fn create_missing_target_dir() -> anyhow::Result<()> {
+            let tmp_dir = assert_fs::TempDir::new()?;
+
+            let project_target = tmp_dir.child("target");
+
+            ensure_target_dir_exists(project_target.path())?;
+            project_target.assert(predicates::path::is_dir());
+
+            Ok(())
+        }
+
+        #[test]
+        fn target_dir_already_exists() -> anyhow::Result<()> {
+            let tmp_dir = assert_fs::TempDir::new()?;
+
+            let project_target = tmp_dir.child("target");
+            project_target.create_dir_all()?;
+
+            ensure_target_dir_exists(project_target.path())?;
+            project_target.assert(predicates::path::is_dir());
+
+            Ok(())
+        }
+    }
+
     #[test]
     fn proper_build_src_files() -> anyhow::Result<()> {
         let project_root = assert_fs::TempDir::new()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::pedantic)]
+
 use anyhow::{self, Context};
 use std::env;
 
@@ -14,23 +16,22 @@ fn main() -> anyhow::Result<()> {
     match cli.command {
         Commands::New { path } => {
             println!("Creating new project {}...", path.display());
-            new::new_project(&path)
+            new::main(&path)
                 .with_context(|| format!("Failed to create project {}", &path.display()))?;
             println!("Project {} created successfully!", path.display());
         }
         Commands::Build => {
             println!("Building project...");
-            build::build_project(&env::current_dir()?)
-                .with_context(|| "Failed to build project.")?;
+            build::main(&env::current_dir()?).with_context(|| "Failed to build project.")?;
             println!("Project built successfully!");
         }
         Commands::Run => {
             println!("Building project...");
-            build::build_project(&env::current_dir()?)
+            build::main(&env::current_dir()?)
                 .with_context(|| "Failed to build project before attempting to run it.")?;
             println!("Project built successfully!");
             println!("Running project...");
-            run::run_project(&env::current_dir()?).with_context(|| "Failed to run project")?;
+            run::main(&env::current_dir()?).with_context(|| "Failed to run project")?;
         }
     };
 

--- a/src/new.rs
+++ b/src/new.rs
@@ -49,14 +49,6 @@ fn create_project_fs(project_root: &Path) -> anyhow::Result<PathBuf> {
         )
     })?;
 
-    // Create `target` directory where all binary files should be.
-    fs::create_dir(project_root.join("target")).with_context(|| {
-        format!(
-            "Failed to create project target directory {}.",
-            project_root.join("target").display()
-        )
-    })?;
-
     Ok(project_root.to_path_buf())
 }
 
@@ -109,11 +101,9 @@ mod tests {
             .with_context(|| "Failed to create project file structure!")?;
 
         let project_src = project_root.child("src");
-        let project_target = project_root.child("target");
 
         project_root.assert(predicates::path::is_dir());
         project_src.assert(predicates::path::is_dir());
-        project_target.assert(predicates::path::is_dir());
 
         Ok(())
     }
@@ -141,11 +131,9 @@ mod tests {
             .with_context(|| "Failed to create project file structure!")?;
 
         let project_src = project_root.child("src");
-        let project_target = project_root.child("target");
 
         project_root.assert(predicates::path::is_dir());
         project_src.assert(predicates::path::is_dir());
-        project_target.assert(predicates::path::is_dir());
 
         Ok(())
     }
@@ -173,13 +161,11 @@ mod tests {
 
         let project_manifest = project_root.child("Cppargo.toml");
         let project_src = project_root.child("src");
-        let project_target = project_root.child("target");
         let project_hello_world = project_src.child("main.cpp");
 
         project_root.assert(predicates::path::is_dir());
         project_manifest.assert("[project]\nname = \"foo\"\n");
         project_src.assert(predicates::path::is_dir());
-        project_target.assert(predicates::path::is_dir());
         project_hello_world.assert(predicates::path::is_file());
 
         Ok(())

--- a/src/new.rs
+++ b/src/new.rs
@@ -15,7 +15,7 @@ const HELLO_WORLD_PROGRAM: &str = concat!(
     "}\n"
 );
 
-pub fn new_project(path: &Path) -> anyhow::Result<()> {
+pub fn main(path: &Path) -> anyhow::Result<()> {
     let project_root: PathBuf =
         create_project_fs(path).with_context(|| "Failed to create project file structure")?;
 

--- a/src/new.rs
+++ b/src/new.rs
@@ -157,7 +157,7 @@ mod tests {
         let tmp_dir = assert_fs::TempDir::new()?;
         let project_root = tmp_dir.child("foo");
 
-        new_project(&project_root).with_context(|| "Failed to create new project!")?;
+        main(&project_root).with_context(|| "Failed to create new project!")?;
 
         let project_manifest = project_root.child("Cppargo.toml");
         let project_src = project_root.child("src");
@@ -166,7 +166,7 @@ mod tests {
         project_root.assert(predicates::path::is_dir());
         project_manifest.assert("[project]\nname = \"foo\"\n");
         project_src.assert(predicates::path::is_dir());
-        project_hello_world.assert(predicates::path::is_file());
+        project_hello_world.assert(HELLO_WORLD_PROGRAM);
 
         Ok(())
     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -5,10 +5,10 @@ use std::{
     process::Command,
 };
 
-pub fn run_project(project_dir: &Path) -> anyhow::Result<()> {
+pub fn main(project_dir: &Path) -> anyhow::Result<()> {
     let project_binary =
         find_project_binary(project_dir).with_context(|| "Failed to find project binary!")?;
-    run_project_binary(project_binary).with_context(|| "Failed to run project binary!")?;
+    run_project_binary(&project_binary).with_context(|| "Failed to run project binary!")?;
 
     Ok(())
 }
@@ -16,9 +16,8 @@ pub fn run_project(project_dir: &Path) -> anyhow::Result<()> {
 fn find_project_binary(project_dir: &Path) -> anyhow::Result<PathBuf> {
     let project_target = project_dir.join("target");
 
-    let project_name = match project_dir.file_name() {
-        Some(name) => name,
-        None => anyhow::bail!("Couldn't get project name."),
+    let Some(project_name) = project_dir.file_name() else {
+        anyhow::bail!("Couldn't get project name.");
     };
 
     let project_binary = project_target.join(project_name);
@@ -31,8 +30,8 @@ fn find_project_binary(project_dir: &Path) -> anyhow::Result<PathBuf> {
     Ok(project_binary)
 }
 
-fn run_project_binary(project_binary: PathBuf) -> anyhow::Result<()> {
-    Command::new(&project_binary)
+fn run_project_binary(project_binary: &PathBuf) -> anyhow::Result<()> {
+    Command::new(project_binary)
         .spawn()
         .with_context(|| {
             format!(

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -22,8 +22,6 @@ fn fail_because_project_has_no_src_files() -> anyhow::Result<()> {
     project_root.create_dir_all()?;
     let project_src = project_root.child("src");
     project_src.create_dir_all()?;
-    let project_target = project_root.child("target");
-    project_target.create_dir_all()?;
 
     let project_manifest = project_root.child("Cppargo.toml");
     project_manifest.write_str(PROJECT_MANIFEST)?;
@@ -38,14 +36,12 @@ fn fail_because_project_has_no_src_files() -> anyhow::Result<()> {
 }
 
 #[test]
-fn succeed() -> anyhow::Result<()> {
+fn succeed_without_existing_target_dir() -> anyhow::Result<()> {
     let tmp_dir = assert_fs::TempDir::new()?;
     let project_root = tmp_dir.child("foo");
     project_root.create_dir_all()?;
     let project_src = project_root.child("src");
     project_src.create_dir_all()?;
-    let project_target = project_root.child("target");
-    project_target.create_dir_all()?;
 
     let project_manifest = project_root.child("Cppargo.toml");
     project_manifest.write_str(PROJECT_MANIFEST)?;
@@ -54,7 +50,35 @@ fn succeed() -> anyhow::Result<()> {
     main_file.write_str(HELLO_WORLD_PROGRAM)?;
 
     let mut cmd = Command::cargo_bin("cppargo")?;
-    cmd.current_dir(tmp_dir.child("foo").path()).arg("build");
+    cmd.current_dir(project_root.path()).arg("build");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Project built successfully!"));
+
+    Ok(())
+}
+
+#[test]
+fn succeed_with_existing_target_dir() -> anyhow::Result<()> {
+    let tmp_dir = assert_fs::TempDir::new()?;
+    let project_root = tmp_dir.child("foo");
+    project_root.create_dir_all()?;
+    let project_src = project_root.child("src");
+    project_src.create_dir_all()?;
+
+    let project_manifest = project_root.child("Cppargo.toml");
+    project_manifest.write_str(PROJECT_MANIFEST)?;
+
+    let main_file = project_src.child("main.cpp");
+    main_file.write_str(HELLO_WORLD_PROGRAM)?;
+
+    let project_target = project_root.child("target");
+    project_target.create_dir_all()?;
+    let existing_binary = project_target.child("foo");
+    existing_binary.touch()?;
+
+    let mut cmd = Command::cargo_bin("cppargo")?;
+    cmd.current_dir(project_root.path()).arg("build");
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("Project built successfully!"));

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -25,6 +25,9 @@ fn fail_because_project_has_no_src_files() -> anyhow::Result<()> {
     let project_target = project_root.child("target");
     project_target.create_dir_all()?;
 
+    let project_manifest = project_root.child("Cppargo.toml");
+    project_manifest.write_str(PROJECT_MANIFEST)?;
+
     let mut cmd = Command::cargo_bin("cppargo")?;
     cmd.current_dir(project_root.path()).arg("build");
     cmd.assert().failure().stderr(predicate::str::contains(
@@ -43,6 +46,9 @@ fn succeed() -> anyhow::Result<()> {
     project_src.create_dir_all()?;
     let project_target = project_root.child("target");
     project_target.create_dir_all()?;
+
+    let project_manifest = project_root.child("Cppargo.toml");
+    project_manifest.write_str(PROJECT_MANIFEST)?;
 
     let main_file = project_src.child("main.cpp");
     main_file.write_str(HELLO_WORLD_PROGRAM)?;

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -7,9 +7,9 @@ fn fail_outside_cppargo_project() -> anyhow::Result<()> {
 
     let mut cmd = Command::cargo_bin("cppargo")?;
     cmd.current_dir(tmp_dir.path()).arg("build");
-    cmd.assert()
-        .failure()
-        .stderr(predicate::str::contains("Not at cppargo project root"));
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "Failed to find project manifest `Cppargo.toml` up to /!",
+    ));
 
     Ok(())
 }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -18,15 +18,15 @@ fn fail_outside_cppargo_project() -> anyhow::Result<()> {
 fn fail_because_project_has_no_src_files() -> anyhow::Result<()> {
     let tmp_dir = assert_fs::TempDir::new()?;
 
-    let project_dir = tmp_dir.child("foo");
-    project_dir.create_dir_all()?;
-    let project_src = project_dir.child("src");
+    let project_root = tmp_dir.child("foo");
+    project_root.create_dir_all()?;
+    let project_src = project_root.child("src");
     project_src.create_dir_all()?;
-    let project_target = project_dir.child("target");
+    let project_target = project_root.child("target");
     project_target.create_dir_all()?;
 
     let mut cmd = Command::cargo_bin("cppargo")?;
-    cmd.current_dir(project_dir.path()).arg("build");
+    cmd.current_dir(project_root.path()).arg("build");
     cmd.assert().failure().stderr(predicate::str::contains(
         "No source `.cpp` files to compile found",
     ));
@@ -37,11 +37,11 @@ fn fail_because_project_has_no_src_files() -> anyhow::Result<()> {
 #[test]
 fn succeed() -> anyhow::Result<()> {
     let tmp_dir = assert_fs::TempDir::new()?;
-    let project_dir = tmp_dir.child("foo");
-    project_dir.create_dir_all()?;
-    let project_src = project_dir.child("src");
+    let project_root = tmp_dir.child("foo");
+    project_root.create_dir_all()?;
+    let project_src = project_root.child("src");
     project_src.create_dir_all()?;
-    let project_target = project_dir.child("target");
+    let project_target = project_root.child("target");
     project_target.create_dir_all()?;
 
     let main_file = project_src.child("main.cpp");

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -9,7 +9,7 @@ fn fail_outside_cppargo_project() -> anyhow::Result<()> {
     cmd.current_dir(tmp_dir.path()).arg("build");
     cmd.assert()
         .failure()
-        .stderr(predicates::str::contains("Not at cppargo project root"));
+        .stderr(predicate::str::contains("Not at cppargo project root"));
 
     Ok(())
 }
@@ -27,7 +27,7 @@ fn fail_because_project_has_no_src_files() -> anyhow::Result<()> {
 
     let mut cmd = Command::cargo_bin("cppargo")?;
     cmd.current_dir(project_dir.path()).arg("build");
-    cmd.assert().failure().stderr(predicates::str::contains(
+    cmd.assert().failure().stderr(predicate::str::contains(
         "No source `.cpp` files to compile found",
     ));
 
@@ -51,7 +51,7 @@ fn succeed() -> anyhow::Result<()> {
     cmd.current_dir(tmp_dir.child("foo").path()).arg("build");
     cmd.assert()
         .success()
-        .stdout(predicates::str::contains("Project built successfully!"));
+        .stdout(predicate::str::contains("Project built successfully!"));
 
     Ok(())
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -28,6 +28,9 @@ fn succeed_build_and_run_project() -> anyhow::Result<()> {
     let project_target = project_root.child("target");
     project_target.create_dir_all()?;
 
+    let project_manifest = project_root.child("Cppargo.toml");
+    project_manifest.write_str(PROJECT_MANIFEST)?;
+
     let main_file = project_src.child("main.cpp");
     main_file.write_str(HELLO_WORLD_PROGRAM)?;
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -21,18 +21,18 @@ fn succeed_create_and_build_project() -> anyhow::Result<()> {
 #[test]
 fn succeed_build_and_run_project() -> anyhow::Result<()> {
     let tmp_dir = assert_fs::TempDir::new()?;
-    let project_dir = tmp_dir.child("foo");
-    project_dir.create_dir_all()?;
-    let project_src = project_dir.child("src");
+    let project_root = tmp_dir.child("foo");
+    project_root.create_dir_all()?;
+    let project_src = project_root.child("src");
     project_src.create_dir_all()?;
-    let project_target = project_dir.child("target");
+    let project_target = project_root.child("target");
     project_target.create_dir_all()?;
 
     let main_file = project_src.child("main.cpp");
     main_file.write_str(HELLO_WORLD_PROGRAM)?;
 
     let mut cmd = Command::cargo_bin("cppargo")?;
-    cmd.current_dir(project_dir.path()).arg("run");
+    cmd.current_dir(project_root.path()).arg("run");
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("Hello World!"));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -13,7 +13,7 @@ fn succeed_create_and_build_project() -> anyhow::Result<()> {
     cmd.current_dir(tmp_dir.child("foo").path()).arg("build");
     cmd.assert()
         .success()
-        .stdout(predicates::str::contains("Project built successfully!"));
+        .stdout(predicate::str::contains("Project built successfully!"));
 
     Ok(())
 }
@@ -35,7 +35,7 @@ fn succeed_build_and_run_project() -> anyhow::Result<()> {
     cmd.current_dir(project_dir.path()).arg("run");
     cmd.assert()
         .success()
-        .stdout(predicates::str::contains("Hello World!"));
+        .stdout(predicate::str::contains("Hello World!"));
 
     Ok(())
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,3 +12,5 @@ pub const HELLO_WORLD_PROGRAM: &str = concat!(
     "    return 0;\n",
     "}\n"
 );
+
+pub const PROJECT_MANIFEST: &str = "[project]\nname = \"foo\"\n";

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -1,14 +1,19 @@
 use predicates::str::{ContainsPredicate, EndsWithPredicate};
-use std::path::Path;
+use std::{ops::Deref, path::Path};
 
 mod common;
 use common::*;
 
 fn ensure_project_created_successfully<T>(project_root: T)
 where
-    T: PathChild + PathAssert,
+    T: PathChild + PathAssert + Deref<Target = Path>,
 {
     project_root.assert(predicates::path::is_dir());
+    let project_manifest = project_root.child("Cppargo.toml");
+    project_manifest.assert(format!(
+        "[project]\nname = \"{}\"\n",
+        project_root.file_name().unwrap().to_str().unwrap()
+    ));
     let project_src = project_root.child("src");
     project_src.assert(predicates::path::is_dir());
     let project_target = project_root.child("target");

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -16,8 +16,6 @@ where
     ));
     let project_src = project_root.child("src");
     project_src.assert(predicates::path::is_dir());
-    let project_target = project_root.child("target");
-    project_target.assert(predicates::path::is_dir());
     let main_file = project_src.child("main.cpp");
     main_file.assert(predicates::path::is_file());
     main_file.assert(HELLO_WORLD_PROGRAM);


### PR DESCRIPTION
- **feat: create `Cppargo.toml` manifest at project root**
- **refactor: stop creating empty `target` subdirectory**
- **feat: utilize manifest for project root and name**
- **feat: ensure target directory exists**
- **refactor: move manifest parsing to own function**
- **refactor: simplify building function**
- **refactor: follow cargo-clippy pedantic suggestions**
- **refactor: improve error messages**
- **test: ensure tests comply with implementation**
- **test: improve finding project root testing**
- **test: modularize finding src files testing cases**
- **refactor: add context to failed parsing of manifest**
- **test: add testing for project name parsing**
- **test: add testing to ensuring target dir exists**
- **test: update build_src_files test**
- **test: update main unit test**
- **test: rename project_dir to project_root**
- **test: include existance of project manifest**
- **refactor: improve error message clarity**
- **test: update tests to match new error message**
- **test: correct target dir testing**
