### PR TITLE
24 require srcmaincpp except when explicitly stated otherwise

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -23,6 +23,14 @@ pub fn main(current_dir: &Path) -> anyhow::Result<()> {
 
     let project_src = project_root.join("src");
 
+    anyhow::ensure!(
+        project_src.join("main.cpp").is_file(),
+        format!(
+            "Missing \"src/main.cpp\" file in {}!",
+            project_src.display()
+        )
+    );
+
     let src_files = find_src_files(&project_src).with_context(|| {
         format!(
             "Failed to gather source files from {}!",

--- a/src/build.rs
+++ b/src/build.rs
@@ -16,6 +16,11 @@ pub fn main(current_dir: &Path) -> anyhow::Result<()> {
         )
     })?;
 
+    let project_manifest = get_project_manifest(&project_root)
+        .with_context(|| "Failed to parse project manifest!")?;
+    let project_name = get_project_name(&project_manifest)
+        .with_context(|| "Failed to parse project name!")?;
+
     let project_src = project_root.join("src");
 
     let src_files = find_src_files(&project_src).with_context(|| {
@@ -24,11 +29,6 @@ pub fn main(current_dir: &Path) -> anyhow::Result<()> {
             project_src.display()
         )
     })?;
-
-    let project_manifest = get_project_manifest(&project_root)
-        .with_context(|| "Failed to parse project manifest!")?;
-    let project_name = get_project_name(&project_manifest)
-        .with_context(|| "Failed to parse project name!")?;
 
     let project_target = project_root.join("target");
     ensure_target_dir_exists(&project_target)

--- a/src/build.rs
+++ b/src/build.rs
@@ -72,13 +72,20 @@ fn find_project_root(dir: &Path) -> anyhow::Result<PathBuf> {
 fn get_project_manifest(project_root: &Path) -> anyhow::Result<toml_edit::DocumentMut> {
     let manifest_path = project_root.join("Cppargo.toml");
 
-    let manifest = toml_edit::DocumentMut::from_str(&fs::read_to_string(&manifest_path)?)
-        .with_context(|| {
+    let manifest = toml_edit::DocumentMut::from_str(
+        &fs::read_to_string(&manifest_path).with_context(|| {
             format!(
-                "Failed to parse project manifest {}!",
+                "Failed to read project manifest {} file!",
                 manifest_path.display()
             )
-        })?;
+        })?,
+    )
+    .with_context(|| {
+        format!(
+            "Failed to parse project manifest {} file!",
+            manifest_path.display()
+        )
+    })?;
 
     Ok(manifest)
 }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -15,7 +15,7 @@ fn fail_outside_cppargo_project() -> anyhow::Result<()> {
 }
 
 #[test]
-fn fail_because_project_has_no_src_files() -> anyhow::Result<()> {
+fn fail_because_project_has_main_file() -> anyhow::Result<()> {
     let tmp_dir = assert_fs::TempDir::new()?;
 
     let project_root = tmp_dir.child("foo");
@@ -29,7 +29,10 @@ fn fail_because_project_has_no_src_files() -> anyhow::Result<()> {
     let mut cmd = Command::cargo_bin("cppargo")?;
     cmd.current_dir(project_root.path()).arg("build");
     cmd.assert().failure().stderr(predicate::str::contains(
-        "No source `.cpp` files to compile found",
+        format!(
+            "Missing \"src/main.cpp\" file in {}!",
+            project_src.display()
+        )
     ));
 
     Ok(())


### PR DESCRIPTION
- **refactor(build): gather project manifest in variable**
- **refactor(build): parse manifest before looking for src files**
- **style(build): move method declaration order**
- **refactor(build): better errors for manifest parsing**
- **refactor(build): better errors for name parsing**
- **test(build): unit tests for manifest parsing**
- **feat(build): fail if `main.cpp` is missing.**
- **test(build): correct integration test**
