### PR TITLE
24 require srcmaincpp for building

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,18 @@ exits with an error due to not being inside a `cppargo` project, as the
 `Cppargo.toml` determines the root of any `cppargo` project.
 
 From the project root, it will look for the `PROJECT_ROOT/src` directory to
-find all of the `.cpp` files insde it. The file structure inside the `src`
-directory is irrelevant to `cppargo`, since it will search exhaustively all
-subdirectories to find all `.cpp` files.
+find all of the `.cpp` files insde it. The first file it looks for, is the
+`src/main.cpp` file. This file is meant to be the main project file, and is
+therefore required to be in the project. If `cppargo` fails to find a
+`src/main.cpp` file, it will exit with an error. This to establish a convention
+for file structure within any `cppargo` project.
 
-Once gathered, all of the `.cpp` files are sent as arguments to `g++`
-to be compiled. This means that `cppargo` does no linkage or compilation of its
-own, nor does it check for any bad `#include` statements, or the lack thereof.
+Apart from the presence of the `src/main.cpp` file, the file structure inside
+the `src` directory is irrelevant to `cppargo`, since it will search
+exhaustively all subdirectories to find all `.cpp` files. Once gathered, all of
+the `.cpp` files are sent as arguments to `g++` to be compiled. This means that
+`cppargo` does no linkage or compilation of its own, nor does it check for any
+bad `#include` statements, or the lack thereof.
 
 The compiled excecutable file is then stored within a `PROJECT_ROOT/target`
 directory. `cppargo` first checks to ensure that the directory exists, and

--- a/src/build.rs
+++ b/src/build.rs
@@ -18,6 +18,14 @@ pub fn main(current_dir: &Path) -> anyhow::Result<()> {
 
     let project_src = project_root.join("src");
 
+    anyhow::ensure!(
+        project_src.join("main.cpp").is_file(),
+        format!(
+            "Missing \"src/main.cpp\" file in {}!",
+            project_src.display()
+        )
+    );
+
     let src_files = find_src_files(&project_src).with_context(|| {
         format!(
             "Failed to gather source files from {}!",

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -15,7 +15,7 @@ fn fail_outside_cppargo_project() -> anyhow::Result<()> {
 }
 
 #[test]
-fn fail_because_project_has_no_src_files() -> anyhow::Result<()> {
+fn fail_because_project_has_no_main_file() -> anyhow::Result<()> {
     let tmp_dir = assert_fs::TempDir::new()?;
 
     let project_root = tmp_dir.child("foo");
@@ -29,7 +29,10 @@ fn fail_because_project_has_no_src_files() -> anyhow::Result<()> {
     let mut cmd = Command::cargo_bin("cppargo")?;
     cmd.current_dir(project_root.path()).arg("build");
     cmd.assert().failure().stderr(predicate::str::contains(
-        "No source `.cpp` files to compile found",
+        format!(
+            "Missing \"src/main.cpp\" file in {}!",
+            project_src.display()
+        )
     ));
 
     Ok(())


### PR DESCRIPTION
- **feat(build): fail if `main.cpp` is missing.**
- **test(build): correct integration test**
- **docs(readme): specify importance of `src/main.cpp`**

Implement a check before looking for any `.cpp` files to ensure that a
`main.cpp` file is present. Hence making sure also that at least a single
`.cpp` file is present, and also making sure that the project follows
filestructure convention.
